### PR TITLE
Update EC commit, multi-lane SPI support

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,8 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        #branch = "refs/changes/70/4336270/27",
-        commit = "17c8bc295fb6c2a258efadb4a52f04a0f494ec0d",
+        commit = "256b891b796853f7be17e2ca59034f08c4ca200b",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
The changes required for HyperDebug firmware to support multi-lane SPI has merged into the Chromium EC repository.