### PR TITLE
Update EC commit, GPIO monitoring fixes

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "256b891b796853f7be17e2ca59034f08c4ca200b",
+        commit = "404e01803921535e6105976a9c3d3f490ceb72e2",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Two fixes for the GPIO monitoring (logic analyzer) functionality of the HyperDebug firmware.  Before this, any SPI transaction would fail if GPIO monitoring was ongoing.  Also, in some circumstances, characters could be lost in the textual protocol used to retrieve GPIO events.