### PR TITLE
Update EC commit, I2C open-drain bugfix

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "af608b1d2711cecb80f396cd26aef1fde400422e",
+        commit = "a46e9d233b0d094256459f613101070f84133a6a",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Correctly maintain open-drain mode on I2C pins across `transport init`.