### PR TITLE
Update EC commit, Support fourth I2C port

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "a46e9d233b0d094256459f613101070f84133a6a",
+        commit = "fbd5697d6ab7a198a5974ab2c75ee620efe61599",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Allow controlling all four I2C ports of the STM32L5 chip through opentitantool.  This means that signals CN10_8 and CN10_12 now default to "alternate" mode, rather than "input".  Any code that uses tham as GPIO inputs without explicitly declaring that mode may stop working.