### PR TITLE
Update EC commit, Support dynamic SPI chip select

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "fbd5697d6ab7a198a5974ab2c75ee620efe61599",
+        commit = "d7c69daa0837e015ee593842ff5f9f85dd046894",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Allow runtime reconfiguration of the pin to use for SPI chip select. This goes together with OpenTitan PR #19482.