### PR TITLE
Update EC commit, support for SPI1, blue button

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "d7c69daa0837e015ee593842ff5f9f85dd046894",
+        commit = "73a4bda214e42181858330dbbd5f971e2547b3f8",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Add SPI1 as another SPI port, in addition to SPI2 and QSPI.  Unlike existing SPI and I2C ports, the pins of SPI1 default to being GPIO, and must explicitly be configured as "Alternate" mode, in order for SPI to be used on them.  This is done to maintain compatibility with existing uses of the pins.

Pressing the blue button on HyperDebug will pull a configurable "reset" pin low (provided it is configured to have output enabled), default is CN10_29.