### PR TITLE
Update EC commit, support for JTAG

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "73a4bda214e42181858330dbbd5f971e2547b3f8",
+        commit = "64eac329fda0bdbdea21768de054402f70f484a2",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Add JTAG support within the CMSIS-DAP protocol.

This bit-banging implementation can operate up to approximately 500kbps, setting the frequency higher will still produce valid JTAG waveforms, but at slower than requested frequency.  (Generated JTAG waveforms are slightly slower than requested no matter which frequency.)