### PR TITLE
Update EC commit, improved GPIO monitoring

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "64eac329fda0bdbdea21768de054402f70f484a2",
+        commit = "cf8fe0e630609a1c49d19255e7ce250cf440d3b0",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Optimizations in the HyperDebug code now allows the recording of one signal edge per microsecond.  This means that if clock speeds are reduced to 100kHz, then I2C and SPI communication can be captured.