### PR TITLE
Update EC commit, I2C device support

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "cf8fe0e630609a1c49d19255e7ce250cf440d3b0",
+        commit = "ec0b07f4b1d938abc7e3b37eabb8661c40982e8a",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Add new "vendor extension" to the CMSIS-DAP USB interface to support switching I2C ports into device mode, meaning that HyperDebug will answer I2C transfers initated by OpenTitan.