### PR TITLE
Update EC commit, gpio monitoring fix

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "19ad8601c6b626f7c42e3889f13c7e3485e16b62",
+        commit = "c22816fc39169d633061ae9670e4eb8c24eec8bd",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Previously, HyperDebug could get confused, if "transport init" was run while there were GPIO monitoring in progress, typically because a test failed or was interrupted before completing.

This would lead into a status where HyperDebug responded correctly, but never recorded any more edge detections, until it was reset.

Also, a Google extension to the CMSIS-DAP protocol for advertising support for other extensions was not properly implemented.  (And has not yet been used by opentitantool.)