### PR TITLE
Update EC commit, I2C device fix

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "c22816fc39169d633061ae9670e4eb8c24eec8bd",
+        commit = "983c86fb0539a9d13798e9c2a620ad7c52508ac3",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
HyperDebug could switch in and out of I2C device mode, but not switch device address, once one was selected.  This patch addresses that shortcoming, such that `opentitantool i2c set-mode device --addr ...` can be repeatedly issued, to change the address.