### PR TITLE
Update EC commit, multiple bugfixes

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "983c86fb0539a9d13798e9c2a620ad7c52508ac3",
+        commit = "66e5906c59cf41a009803e2097b6810ca2775f2e",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
HyperDebug was prone to dropping serial data if the USB host failed to issue IN transactions for just a few milliseconds, if the OT chip was producing characters at maximum speed.

Also, overflow during GPIO monitoring could put HyperDebug into a state in which subsequent GPIO monitoring operations would silently fail to capture edges.