### PR TITLE
Update EC commit, binary GPIO monitoring protocol

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "66e5906c59cf41a009803e2097b6810ca2775f2e",
+        commit = "f2e0348f08352b88e005262df5494162013bbe16",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
HyperDebug has memory to buffer tens of thousands of GPIO edge events, when using the `GpioMonitoring` functionality.  However, transferring them to opentitantool via the text console protocol over USB was inefficient.  This change includes a new "vendor extension" to the binary CMSIS-DAP protocol, to be used for efficiently retrieving many events (basically a memory dump of the internal buffer.)