### PR TITLE
Update EC commit, QSPI bugfix

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "a8f2dc71df133c3474ab977d7e3b278fe22a6a99",
+        commit = "2adaee5e5cf905c0c1cff56e1661e12544d17b58",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Under some circumstances, HyperDebug could generate corrupted SPI waveforms on second and subsequent attempts.

As a workaround, this CL pulls in code to resets the OCTOSPI IP block of HyperDebug between transaction, which adds negligible delay