### PR TITLE
Update EC commit, UART and reinit bugfixes

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "fbefdb4114469f9ce2f0f85c1669fd022e6d62eb",
+        commit = "0479dbbf3b1fc27ab4cbf2e36c252609c46fec4c",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Several bugfixes to make sure UARTs and other HyperDebug state is properly reset to power-on defaults on "transport init".

81331c5b9b board/hyperdebug: Bring CMSIS-DAP to initial state on reini
38292cdb87 board/hyperdebug: Clear UART buffers on reinit
424cb71df5 chip/stm32: Add support for emptying UART buffers
9503ba1529 chip/stm32: Fix for "deadlock" in UART forwarding
ec212306d1 board/hyperdebug: Reset UARTs to default settings on reinit