### PR TITLE
Update EC commit, advanced bit-banging

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "0479dbbf3b1fc27ab4cbf2e36c252609c46fec4c",
+        commit = "079eda8c6d0cbc8cea1210319b56b48d3c76e574",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Add support for the `await()` feature in bitbanging pattern, allowing waveform to stop a particular points, waiting for certain inputs before proceeding.  This is useful e.g. for bit-banging an I2C host, when the I2C device may stretch the clock, or for generating waveforms are precise timing relative to some trigger from the chip under test.

34f0cfdfcc board/hyperdebug: Bit bang support for triggers
6e10acec2f board/hyperdebug: No-op refactoring
0c6e97ee41 board/hyperdebug: Central declaration of timer assignment
6e9838a098 board/hyperdebug: Declare pins on CN11 and CN12