### PR TITLE
Update EC commit, faster UART

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "079eda8c6d0cbc8cea1210319b56b48d3c76e574",
+        commit = "37c9854cbacd275e714491c65018e151fb22d1a6",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
This firmware update allows HyperDebug uarts to run at up to 1.5Mbaud (even faster speeds are possible, but not with sustained maximum throughput.)  Also the use of STM EC instruction cache should allow faster bit-banging and generally slightly reduced latency, and a bugfix allows JTAG on other pins than the default ones.

37c9854cba board/hyperdebug: Improve USB serial forwarding
ce6f991714 chip/stm32: Allow less than 64 bytes for USB EP0
c2e9c1ff9a board/hyperdebug: Fix bug in JTAG pin reassignment
90ef6548f0 chip/stm32: Configurable UART clock source for STM32L5
805db3146e chip/stm32: Disable UART while changing baud
77e1852e81 chip/stm32: Proper UART initialization on STM32L5
9c1266a6d2 chip/stm32: Enable instruction cache for STM32L5
d82cf823f5 chip/stm32: Configure DBGMCU for STM32L5
4bd3d7532e board/hyperdebug: Use timer 7 for JTAG bit banging
956cba906e board/hyperdebug: Use timer 6 for bit banging
35bea995f0 chip/stm32: Support more timers on L4/L5
e429d84a00 board/hyperdebug: Allow ST-link debugging by default