### PR TITLE
Update EC commit, fix for ADC calibration

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "2eac9058cd6fb4e8baf687ec67fe9a128eb8d08f",
+        commit = "c4707ad93c766bb9027e7e56fff7b1b06342cfab",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
This update fixes an issue whereby occasional issues with the ADC calibration would lead to HyperDebug firmware crashing due to a division by zero.

c4707ad93c chip/stm32: Fix ADC calibration delay on STM32L4/5