### PR TITLE
Update EC commit, TPM feature, UART optimization, fixes

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "c4707ad93c766bb9027e7e56fff7b1b06342cfab",
+        commit = "87399ae831449d6a392586dc7972a7292d02dd14",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
This update includes several improvements:

* New SPI/I2C features to perform TPM operations in a single USB roundtrip.

* Vastly improve efficiency of UART data forwarded via USB.

* Fix to bit-banging, which could previously incorrectly complain about "ongoing operation", if the most recent bit-banging had ended less than one clock-tick ago.  (This clock could be arbitrarily slow.  The problem showed up when bit-banging simulated key presses with a 20ms clock, and the next operation was attempted initiated less than 20ms after the previous one had applied its last sample.)

* ADC calibration did not entirely adhere to STM32 timing requirements, resulting in occasional crash during "reinit" (transport init).

Relevant CLs:
87399ae831 board/hyperdebug: Reduce USB fragmentation in CMSIS-DAP 261e3ec718 chip/stm32: L4/L5 UART driver makes use of RX timeout ab72b9eaf8 chip/stm32: USB stream driver delays outbound USB packet until flush 19e0f86cd3 chip/stm32: Remove unused fields
3006f5bffb common: Introduce buffered mode and queue_flush() 46b9a8797e board/hyperdebug: Implement tailored logic for TPM I2C devices 5cbea1dba5 board/hyperdebug: Implement tailored logic for TPM SPI devices 8115337458 board/hyperdebug: Route all SPI requests through board code d2a6c10ad5 board/hyperdebug: Support bit-banging in quick succession 7760f99e7d board/hyperdebug: ADC calibration robustness 513b83b195 chip/stm32: Correct ADC initialization timing 3024d3eb68 chip/stm32: Larger console UART buffer for STM32L5 c4707ad93c chip/stm32: Fix ADC calibration delay on STM32L4/5