### PR TITLE
Adapt to Makefile changes in ChromeOS EC repository

### DIFF
--- a/third_party/chromium/BUILD.ec_src.bazel
+++ b/third_party/chromium/BUILD.ec_src.bazel
@@ -28,7 +28,7 @@ make(
         "BOARD=hyperdebug",
         "ALLOW_CONFIG=1",
         "BUILDCC_PREFIX={}".format(host_prefix),
-        "CROSS_COMPILE_arm={}/{}".format(bazel_root, arm_prefix),
+        "CROSS_COMPILE={}/{}".format(bazel_root, arm_prefix),
         "out=$$INSTALLDIR$$",
     ],
     build_data = [

--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -12,6 +12,7 @@ def chromium_repos():
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",
+            "//third_party/chromium:work-with-old-gcc-10.patch",
         ],
         patch_args = ["-p1"],
     )

--- a/third_party/chromium/work-with-old-gcc-10.patch
+++ b/third_party/chromium/work-with-old-gcc-10.patch
@@ -1,0 +1,13 @@
+diff --git a/Makefile.toolchain b/Makefile.toolchain
+index 76a0504e35..97b1267e3d 100644
+--- a/Makefile.toolchain
++++ b/Makefile.toolchain
+@@ -210,7 +210,7 @@ ifneq ($(CROSS_COMPILE_CC_NAME),clang)
+ # is set to 0 such that GCC never generates any warnings for the constant
+ # address pointers. For more details, refer to the GCC PR99578.
+ ifneq ($(BOARD), host)
+-CFLAGS+= --param min-pagesize=0
++
+ endif
+ endif
+ ifneq ($(CROSS_COMPILE_CC_NAME),clang)


### PR DESCRIPTION
The build system has been slightly changed, requiring a slight change in how to specify the path to the cross compiler.

Also, the EC codebase now assumes GCC 11 or above, while even the newest lowRISC/crt provides gcc 10.3.1.  So a small patch was required, as the older GCC does not recognize the `min-pagesize` parameter for controlling GCC warnings.