### PR TITLE
Update EC commit, Fix to TPM "GSC ready" logic

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "87399ae831449d6a392586dc7972a7292d02dd14",
+        commit = "a3d721e81c4c69821c9eaccb3aac632b519c3852",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
A single bugfix to recently introduced feature to optionally have SPI or I2C TPM operations recognize Google's "TPM ready" signal.

a3d721e81c board/hyperdebug: Corrections to TPM "GSC ready" logic