### PR TITLE
Update EC commit, support 48Mhz clock generation, and bugfixes

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "a3d721e81c4c69821c9eaccb3aac632b519c3852",
+        commit = "6e9f274d2c888e08cfff1dbdccb299a53a761683",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Add ability to change HyperDebug core clock frequency.  Choosing 96 MHz will allow any PWM capable pin to produce a 48 MHz clock suitable for driving a NuvoTitan chip.  (CN10.31 is the only pin that can output 96 MHz.)

Also included are a few bugfixes to HyperDebug polling the "GSC ready" signal when passing through TPM operations.

Relevant CLs:
6e9f274d2c board/hyperdebug: Improve GSC ready pulse detection
843d7ee9a6 board/hyperdebug: Expect GSC ready pulse after transaction
1b9f351528 board/hyperdebug: Properly set system timer tick rate
3962928140 board/hyperdebug: Allow runtime changes to system clock
821e9349d2 chip/stm32: Consolidate clock enums
e7f8842e93 chip/stm32: Rename STM32_HSE_CLOCK to CONFIG_STM32_CLOCK_HSE_HZ
a8fc0258fe board/hyperdebug: Fast clock output on CN10.31
6265770002 board/hyperdebug: Add support for PWM via low power timers
195271c11d board/hyperdebug: Refactor PWM
fbf583383f board/hyperdebug: Fix off-by-one and rounding errors