### PR TITLE
Update EC commit, bugfix for old issue

### DIFF
--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -75,7 +75,7 @@
   "moduleExtensions": {
     "//:extensions.bzl%sources": {
       "general": {
-        "bzlTransitiveDigest": "crW/wPcfxF+qD+gvfUik5CfPLbuuzArVu4Isxj28I+I=",
+        "bzlTransitiveDigest": "sL1AbasrQUtiw0rpatdbROotSJ1PRKa/EsyzMKvcO80=",
         "usagesDigest": "5YW6ZI0TTWi1Ue9tnGlTzGSpj71MpwGn4UTFwZPtJQc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
@@ -86,7 +86,7 @@
             "ruleClassName": "git_repository",
             "attributes": {
               "remote": "https://chromium.googlesource.com/chromiumos/platform/ec",
-              "commit": "a3d721e81c4c69821c9eaccb3aac632b519c3852",
+              "commit": "765b8a9d2b494c16db85ed6981fda449dfeccbe0",
               "build_file": "@@//third_party/chromium:BUILD.ec_src.bazel",
               "patches": [
                 "@@//third_party/chromium:ec-custom-version.patch",

--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "6e9f274d2c888e08cfff1dbdccb299a53a761683",
+        commit = "765b8a9d2b494c16db85ed6981fda449dfeccbe0",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
It turns out that HyperDebug firmware never used the fully correct procedure for switching to fast clock frequency, failing to wait for core power rail to stabilize at higher voltage, before switching the clock source.

This resulted in undefined behavior on startup.  By accident/chance we have not seen any advese effects until the last batch of changes, which seems to randomly have triggered an isue.

765b8a9d2b chip/stm32: Wait for core voltage to stabilize on STM32L4/5