### PR TITLE
Update EC commit, fix crashing firmware

### DIFF
--- a/third_party/chromium/repos.bzl
+++ b/third_party/chromium/repos.bzl
@@ -8,7 +8,7 @@ def chromium_repos():
     git_repository(
         name = "ec_src",
         remote = "https://chromium.googlesource.com/chromiumos/platform/ec",
-        commit = "765b8a9d2b494c16db85ed6981fda449dfeccbe0",
+        commit = "86c39f0b42d4d919583b59c1e44d7f5aa50e147d",
         build_file = "//third_party/chromium:BUILD.ec_src.bazel",
         patches = [
             "//third_party/chromium:ec-custom-version.patch",


### PR DESCRIPTION
Another recently introduced bug could cause HyperDebug firmware to crash upon setting of QSPI clock speed.  It was introduced as part of the support for runtime changes to core clock frequency, in order to support 48MHz clock generation by HyperDebug.

Relevant CLs:
d090a07063 chip/stm32: Avoid stuck UART to USB forwarding
b3c959b5c5 board/hyperdebug: Avoid clobbering CCR_CFGR register